### PR TITLE
fix: freeze overlay not appearing & timer ending when set to freeze

### DIFF
--- a/backend/controllers/adminController.ts
+++ b/backend/controllers/adminController.ts
@@ -41,11 +41,10 @@ const commandChannel = (req: Request, res: Response) => {
 
 const setAdminCommand = (req: Request, res: Response) => {
     const newcommand = req.body.command;
-    const newround = req.body.round;
+    const newround: string = req.body.round;
 
-    if (newround != round) {
-      setEndTimer(true);
-      console.log(newround);
+    if (newround.toLowerCase() != round.toLowerCase()) {
+      setEndTimer(true);;
       let duration: number;
 
       if (newround == 'EASY') {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -165,6 +165,7 @@ function App() {
 				<Router>
 					<Routes>
 						{/* Login page */}
+						<Route index element={<LoginPage />} />
 
 						{/* Pages with same backgrounds */}
 						<Route path="/" element={<Layout />}>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,7 +18,6 @@ import {
 } from 'pages/';
 import { theme } from 'theme.js';
 
-import { OverlayProvider, overlayContext } from 'utils/OverlayProvider';
 import { baseURL } from 'utils/constants';
 import { postFetch } from 'utils/apiRequest';
 import Cookies from "universal-cookie";
@@ -29,31 +28,12 @@ import { socketClient } from 'socket/socket';
 var immortalHTML = '<div class="MuiBox-root css-1ato3wx"><div class="MuiBox-root css-1xpmd5v"><svg class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium fOverlay css-i4bv87-MuiSvgIcon-root" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="HourglassFullTwoToneIcon" style="font-size: 10rem; align-self: center;"><path d="m8 7.5 4 4 4-4V4H8zm0 9V20h8v-3.5l-4-4z" opacity=".3"></path><path d="M18 2H6v6h.01L6 8.01 10 12l-4 4 .01.01H6V22h12v-5.99h-.01L18 16l-4-4 4-3.99-.01-.01H18zm-2 14.5V20H8v-3.5l4-4zm0-9-4 4-4-4V4h8z"></path></svg><br><h4 class="MuiTypography-root MuiTypography-h4 fOverlay css-1cvibvw-MuiTypography-root">Your screen has been frozen. <br>Please Wait.</h4></div></div>';
 
 
-/**
- * This will set the common background for all pages (except login page)
- */
-function Layout() {
-	return (
-		<Box
-			style={{
-				backgroundImage: `url(${GeneralBackground})`,
-				backgroundSize: 'cover',
-				height: '100vh',
-				overflow: 'hidden',
-			}}
-			id="commonBox"
-		>
-			{/* Children will be displayed through outlet */}
-			<Outlet />
-		</Box>
-	);
-}
-
 
 function App() {
-	const [freezeOverlay, setFreezeOverlay] = useState(overlayContext);
-	// const [loadingOverlay, setLoadingOverlay] = useState(overlayContext);
 
+
+
+	const [freezeOverlay, setFreezeOverlay] = useState(false);
 	const overlayFreezeLoad = useRef(false);
 
 	const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -79,6 +59,29 @@ function App() {
 		//}, 1000);
 	}
 
+	/**
+	 * This will set the common background for all pages (except login page)
+	 */
+	function Layout() {
+		return (
+			<Box
+				style={{
+					backgroundImage: `url(${GeneralBackground})`,
+					backgroundSize: 'cover',
+					height: '100vh',
+					overflow: 'hidden',
+				}}
+				id="commonBox"
+			>
+				{/* Children will be displayed through outlet */}
+				{freezeOverlay ? <div className='fOverlayScreen' style={{zIndex: "10000"}}><FreezeOverlay /></div> : null}
+				<Outlet />
+			</Box>
+		);
+	}
+
+	// state for context API
+	//const [userDetails, setUserDetails] = useContext(userDetailsContext ?? null);
 
 	useEffect(() => {
 		const eventSource = new EventSource(`${baseURL}/admincommand`);
@@ -159,43 +162,24 @@ function App() {
 
 	return (
 		<ThemeProvider theme={theme}>
-			<OverlayProvider>
 				<Router>
 					<Routes>
 						{/* Login page */}
-						<Route index element={<LoginPage />} />
 
 						{/* Pages with same backgrounds */}
 						<Route path="/" element={<Layout />}>
 							<Route path="participant/view-all-problems" 
-								element={
-									<ViewAllProblemsPage 
-										isLoggedIn={isLoggedIn} 
-										setIsLoggedIn={setIsLoggedIn} 
-										checkIfLoggedIn={checkIfLoggedIn}
-										currRound={currRound}
-										setCurrRound={setCurrRound}
-										//seconds={sec}
-									/>}
-							/>
-							<Route path="participant/view-specific-problem"
-								element={
-									<ViewSpecificProblemPage
-										isLoggedIn={isLoggedIn}
-										setIsLoggedIn={setIsLoggedIn}
-										checkIfLoggedIn={checkIfLoggedIn}
-									/>
-								}
-							/>
-							<Route path="judge/submissions"
-								element={
-									<ViewSubmissionsPage
-										isLoggedIn={isLoggedIn}
-										setIsLoggedIn={setIsLoggedIn}
-										checkIfLoggedIn={checkIfLoggedIn}
-									/>
-								}
-							/>
+								element={<ViewAllProblemsPage 
+									isLoggedIn={isLoggedIn} 
+									setIsLoggedIn={setIsLoggedIn} 
+									checkIfLoggedIn={checkIfLoggedIn}
+									currRound={currRound}
+									setCurrRound={setCurrRound}
+									//seconds={sec}
+									 />} />
+							<Route path="participant/view-specific-problem" element={<ViewSpecificProblemPage isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} checkIfLoggedIn={checkIfLoggedIn} />} />
+							<Route path="judge/submissions" element={<ViewSubmissionsPage isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} checkIfLoggedIn={checkIfLoggedIn} />} />
+
 							<Route path="admin/general" 
 								element={<GeneralOptionsPage 
 									isLoggedIn={isLoggedIn} 
@@ -208,29 +192,13 @@ function App() {
 									checked={checked}
 									setChecked={setChecked}
 									/>} />
-							<Route path="admin/logs"
-								element={
-									<PowerUpLogs
-										isLoggedIn={isLoggedIn}
-										setIsLoggedIn={setIsLoggedIn}
-										checkIfLoggedIn={checkIfLoggedIn}
-									/>
-								}
-							/>
-							<Route path="admin/podium"
-								element={
-									<TopTeamsPage
-										isLoggedIn={isLoggedIn}
-										setIsLoggedIn={setIsLoggedIn}
-										checkIfLoggedIn={checkIfLoggedIn}
-									/>
-								}
-							/>
+							<Route path="admin/logs" element={<PowerUpLogs isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} checkIfLoggedIn={checkIfLoggedIn} />} />
+							<Route path="admin/podium" element={<TopTeamsPage isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} checkIfLoggedIn={checkIfLoggedIn} />} />
+
 						</Route>
 					</Routes>
 					<ToastContainerConfig />
 				</Router>
-			</OverlayProvider>
 		</ThemeProvider>
 	);
 }


### PR DESCRIPTION
My logs from Discord:

Nat — Today at 10:52 PM
Discovered errors:
[E1] Freeze overlay not showing up when admin chose to freeze all
[E2] Timer stopping, and then not resuming when freeze is cancelled

E1 and E2 may be linked 

Cause of [E1]:
Seems to be from commit: Merge pull request #60 from COSS-Dev-Team-Code-Wars/ui/additional-detail…

Nat — Today at 11:09 PM
How [E1] was resolved:
Restore old version of code blocks in App.jsx related to overlay

[E2] is still not resolved. Determined to not be directly related to [E1].

Nat — Today at 11:45 PM
Cause of [E2]:
A capitalization error.
For example:

round = "EASY"
newround = "easy"

if (round != newround) endTimer()